### PR TITLE
Deprecate this auth module

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@ fcrepo-module-auth-rbacl
 
 [![Build Status](https://travis-ci.org/fcrepo4-exts/fcrepo-module-auth-rbacl.png?branch=master)](https://travis-ci.org/fcrepo4-exts/fcrepo-module-auth-rbacl)
 
+### WARNING
+---
+
+_**This authorization module is deprecated and will be moved to [fcrepo4-archive](https://github.com/fcrepo4-archive)**_
+
+---
+
 Role Based Authorization Delegate Module for the Fedora 4 Repository
 
 This module is based on the design documented here: https://wiki.duraspace.org/display/FEDORA4x/Basic+Role-based+Authorization+Delegate

--- a/fcrepo-auth-roles-basic/src/main/java/org/fcrepo/auth/roles/basic/BasicRolesAuthorizationDelegate.java
+++ b/fcrepo-auth-roles-basic/src/main/java/org/fcrepo/auth/roles/basic/BasicRolesAuthorizationDelegate.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 /**
  * @author Gregory Jansen
  */
+@Deprecated
 public class BasicRolesAuthorizationDelegate extends AbstractRolesAuthorizationDelegate {
 
     public static final String EVERYONE_NAME = "EVERYONE";
@@ -62,6 +63,11 @@ public class BasicRolesAuthorizationDelegate extends AbstractRolesAuthorizationD
     public boolean rolesHavePermission(final Session userSession,
             final String absPath,
             final String[] actions, final Set<String> roles) {
+        LOGGER.warn("===========================");
+        LOGGER.warn("This authorization provider is deprecated and will be removed in a future release of Fedora: {}",
+                this.getClass());
+        LOGGER.warn("===========================");
+
         if (roles.isEmpty()) {
             LOGGER.debug("A caller without content roles can do nothing in the repository.");
             return false;


### PR DESCRIPTION
* Add note to README
* Add warning message whenever authorization delegate is invoked

Resolves: https://jira.duraspace.org/browse/FCREPO-2529

# To test
* Changes to fcrepo-webapp-plus must be made to enable the use of the auth module
** Guidance: https://gist.github.com/awoods/08e3473031b3883fe9e446268e46c769
* This PR must be built locally
* The updated fcrepo-webapp-plus must be built along the lines of:
```bash
mvn clean install -Prbacl -DskipTests
```
* Run fcrepo-webapp-plus
```bash
mvn -Dfcrepo.modeshape.configuration=classpath:/config/servlet-auth/repository.json  jetty:run -Prbacl
```
* Test
```
curl -i -uuser1:password1 localhost:8080/rest/
```