### PR TITLE
Update version to 5.0.0-SNAPSHOT

### DIFF
--- a/fcrepo-auth-roles-basic/pom.xml
+++ b/fcrepo-auth-roles-basic/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo-module-auth-rbacl</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>fcrepo-auth-roles-basic</artifactId>
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>org.fcrepo</groupId>
       <artifactId>fcrepo-auth-common</artifactId>
-      <version>4.8.0-SNAPSHOT</version>
+      <version>5.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.fcrepo</groupId>

--- a/fcrepo-auth-roles-common/pom.xml
+++ b/fcrepo-auth-roles-common/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo-module-auth-rbacl</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>fcrepo-auth-roles-common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo</artifactId>
-    <version>4.8.0-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>fcrepo-module-auth-rbacl</artifactId>
   <packaging>pom</packaging>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2575

# What does this Pull Request do?
Just bumps the version of fcrepo-module-auth-rbacl to `5.0.0-SNAPSHOT`.  _We were not planning to update this one, but it seems `fcrepo-module-auth-webac` depends on it`_

# What's new?
Development on master breaks the 5.0.0 threshold, and invites breaking API changes.

# How should this be tested?

* Build Fedora `5.0.0-SNAPSHOT` via `mvn clean install`
* Build `fcrepo-module-auth-rbacl` via `mvn clean install`
* Check artifacts in `~/.m2/repository/org/fcrepo` for anything untoward

# Interested parties
@fcrepo4/committers
